### PR TITLE
Fix #4: Unknown server error message

### DIFF
--- a/webclient/api.py
+++ b/webclient/api.py
@@ -37,6 +37,8 @@ def api_call(method, path, params=None, json=None, session=None, return_errors=F
             if return_errors:
                 return (None, "Data not found")
             error_response = redirect("error", message="Data not found")
+        elif r.status_code == 400 and path[0] == "server":
+            error_response = redirect("error", message="Unknown server")
         elif return_errors:
             error = str(r.json().get("errors", "API call failed"))
             return (None, error)


### PR DESCRIPTION
This solves issue #4 and now shows a message "Unknown server" if the master server api returns a 400 error and the first path element in the url is 'server': 
![image](https://user-images.githubusercontent.com/3177915/114274628-b23df280-9a1f-11eb-95db-36f3515aa256.png)

Because all api calls go through this one method, this was the only place I could detect the error and put the new error message without rearchitecting a bunch. Given my lack of python skills I don't think that would have gone over quite well ;-) 