### PR TITLE
Fix: adjust to new field-names in API and optimize server detail ordering

### DIFF
--- a/webclient/pages/servers.py
+++ b/webclient/pages/servers.py
@@ -10,44 +10,6 @@ from ..helpers import (
     template,
 )
 
-LANGUAGES = {
-    0: "All",
-    1: "English",
-    2: "German",
-    3: "French",
-    4: "Brazillian",
-    5: "Bulgarian",
-    6: "Chinese",
-    7: "Czech",
-    8: "Danish",
-    9: "Dutch",
-    10: "Esperanto",
-    11: "Finnish",
-    12: "Hungarian",
-    13: "Icelandic",
-    14: "Italian",
-    15: "Japanese",
-    16: "Korean",
-    17: "Lithuanian",
-    18: "Norwegian",
-    19: "Polish",
-    20: "Portuguese",
-    21: "Romanian",
-    22: "Russian",
-    23: "Slovak",
-    24: "Slovenian",
-    25: "Spanish",
-    26: "Swedish",
-    27: "Turkish",
-    28: "Ukranian",
-    29: "Afrikaans",
-    30: "Croatian",
-    31: "Catalan",
-    32: "Estonian",
-    33: "Galician",
-    34: "Greek",
-    35: "Latvian",
-}
 MAPSETS = {
     0: "Temperate",
     1: "Arctic",
@@ -174,7 +136,7 @@ def _split_version(raw_version):
 
 def _sort_servers(servers):
     servers.sort(
-        key=lambda x: _split_version(x["info"]["server_revision"])
+        key=lambda x: _split_version(x["info"]["openttd_version"])
         + [x["info"]["clients_on"], x["info"]["companies_on"]],
         reverse=True,
     )
@@ -197,7 +159,7 @@ def _list_servers(filter):
 
     servers = _server_list_cache["servers"]
     if filter:
-        servers = [server for server in servers if server["info"]["server_revision"].startswith(filter)]
+        servers = [server for server in servers if server["info"]["openttd_version"].startswith(filter)]
 
     expire = datetime.utcfromtimestamp(_server_list_cache["expire"]).strftime("%Y-%m-%d %H:%M:%S") + " UTC"
     clients = sum([server["info"]["clients_on"] for server in servers])
@@ -212,7 +174,6 @@ def _list_servers(filter):
         servers_ipv4=servers_ipv4,
         servers_ipv6=servers_ipv6,
         filter=filter,
-        languages=LANGUAGES,
         mapsets=MAPSETS,
     )
 
@@ -248,4 +209,4 @@ def server_entry(server_id):
 
     expire = datetime.utcfromtimestamp(_server_entry_cache[server_id]["expire"]).strftime("%Y-%m-%d %H:%M:%S") + " UTC"
 
-    return template("server_entry.html", server=server, expire=expire, languages=LANGUAGES, mapsets=MAPSETS)
+    return template("server_entry.html", server=server, expire=expire, mapsets=MAPSETS)

--- a/webclient/templates/server_entry.html
+++ b/webclient/templates/server_entry.html
@@ -1,15 +1,33 @@
 {% extends 'base.html' %}
 {% block header %}
-    <h1>{% block title %}{{ server["info"]["server_name"] }} {% endblock %}</h1>
+    <h1>{% block title %}{{ server["info"]["name"] }} {% endblock %}</h1>
 {% endblock %}
 {% block content %}
 <p class="cached">This information is cached till {{ expire }}.</p>
 <table id="server-info-table">
     <tbody>
         <tr class="odd">
-            <th>Online:</th>
+            <th>Server address(es):</th>
             <td>
-                {% if server["online"] %}
+                {% if "ipv4" in server %}
+                {{ server["ipv4"]["ip"] }}:{{ server["ipv4"]["port"] }}
+                {% endif %}
+                {% if "ipv4" in server and "ipv6" in server %}<br>{% endif %}
+                {% if "ipv6" in server %}
+                [{{ server["ipv6"]["ip"] }}]:{{ server["ipv6"]["port"] }}
+                {% endif %}
+            </td>
+        </tr>
+        <tr class="even">
+            <th>Server version:</th>
+            <td>
+                {{ server["info"]["openttd_version"] }}
+            </td>
+        </tr>
+        <tr class="odd">
+            <th>Server password:</th>
+            <td>
+                {% if server["info"]["use_password"] == 1 %}
                     Yes
                 {% else %}
                     No
@@ -17,15 +35,15 @@
             </td>
         </tr>
         <tr class="even">
-            <th>First seen:</th>
+            <th>Start date:</th>
             <td>
-                {{ server["time_first_seen"] }}
+                {{ server["info"]["start_date"] }}
             </td>
         </tr>
         <tr class="odd">
-            <th>Last queried:</th>
+            <th>Current date:</th>
             <td>
-                {{ server["time_last_seen"] }}
+                {{ server["info"]["game_date"] }}
             </td>
         </tr>
         <tr class="even">
@@ -47,21 +65,9 @@
             </td>
         </tr>
         <tr class="odd">
-            <th>Language:</th>
-            <td>
-                {{ languages[server["info"]["server_lang"]] }}
-            </td>
-        </tr>
-        <tr class="even">
-            <th>Map name:</th>
-            <td>
-                {{ server["info"]["map_name"] }}
-            </td>
-        </tr>
-        <tr class="odd">
             <th>Landscape:</th>
             <td>
-                {{ mapsets[server["info"]["map_set"]] }}
+                {{ mapsets[server["info"]["map_type"]] }}
             </td>
         </tr>
         <tr class="even">
@@ -71,59 +77,19 @@
             </td>
         </tr>
         <tr class="odd">
-            <th>Server version:</th>
-            <td>
-                {{ server["info"]["server_revision"] }}
-            </td>
-        </tr>
-        <tr class="even">
-            <th>Server address(es):</th>
-            <td>
-                {% if "ipv4" in server %}
-                {{ server["ipv4"]["ip"] }}:{{ server["ipv4"]["port"] }}
-                {% endif %}
-                {% if "ipv4" in server and "ipv6" in server %}<br>{% endif %}
-                {% if "ipv6" in server %}
-                [{{ server["ipv6"]["ip"] }}]:{{ server["ipv6"]["port"] }}
-                {% endif %}
-            </td>
-        </tr>
-        <tr class="odd">
             <th>Dedicated server:</th>
             <td>
-                {% if server["info"]["dedicated"] == 1 %}
+                {% if server["info"]["is_dedicated"] == 1 %}
                     Yes
                 {% else %}
                     No
                 {% endif %}
-            </td>
-        </tr>
-        <tr class="even">
-            <th>Server password:</th>
-            <td>
-                {% if server["info"]["use_password"] == 1 %}
-                    Yes
-                {% else %}
-                    No
-                {% endif %}
-            </td>
-        </tr>
-        <tr class="odd">
-            <th>Start date:</th>
-            <td>
-                {{ server["info"]["start_date"] }}
-            </td>
-        </tr>
-        <tr class="even">
-            <th>Current date:</th>
-            <td>
-                {{ server["info"]["game_date"] }}
             </td>
         </tr>
         <tr class="odd">
             <th>NewGRFs in use:</th>
             <td>
-                {{ server["info"]["num_grfs"] }}
+                {{ server["info"]["newgrfs"]|length }}
             </td>
         </tr>
     </tbody>

--- a/webclient/templates/server_list.html
+++ b/webclient/templates/server_list.html
@@ -31,7 +31,7 @@
 {% for server in servers %}
     <tr class="{{ loop.cycle('odd', 'even') }}">
         <td class="image">
-            {% if server['info']['dedicated'] == 1 %}
+            {% if server['info']['is_dedicated'] == 1 %}
                 <img src="/static/img/server-dedicated.png" alt="Dedicated" title="Dedicated">
             {% else %}
                 <img src="/static/img/server-client.png" alt="Non-Dedicated" title="Non-Dedicated">
@@ -40,7 +40,7 @@
         <td>
             <div class="nowrap" style="width: 562px;">
                 <a href="/server/{{ server['server_id'] }}">
-                    {{ server['info']['server_name'] }}
+                    {{ server['info']['name'] }}
                 </a>
             </div>
         </td>
@@ -52,7 +52,7 @@
         </td>
         <td>
             <div class="nowrap" style="width: 120px;">
-                <a href="/listing/{{ server['info']['server_revision'] }}">{{ server['info']['server_revision'] }}</a>
+                <a href="/listing/{{ server['info']['openttd_version'] }}">{{ server['info']['openttd_version'] }}</a>
             </div>
         </td>
         <td class="image">
@@ -61,7 +61,7 @@
             {% endif %}
         </td>
         <td class="image">
-            {% if server['info']['num_grfs'] > 0 %}
+            {% if server['info']['newgrfs']|length > 0 %}
                 <img src="/static/img/server-grf.png" alt="GRF" title="NewGRFs Required">
             {% endif %}
         </td>


### PR DESCRIPTION
The JSON on the API changed slightly. See https://github.com/OpenTTD/master-server/pull/35.

Additionally, the "server detail" order of fields has bugged me for some time now. I resorted it to have the most useful fields on top (address of server, password, ..). Also removed fields like "last queried", that will be deprecated soon anyway, but also didn't really add value.

The field "online" was just stupid, as it always said "true".