### PR TITLE
Add: show "Unknown" if we don't know the server uses a gamescript

### DIFF
--- a/webclient/templates/server_entry.html
+++ b/webclient/templates/server_entry.html
@@ -98,19 +98,23 @@
         <tr class="even">
             <th>Gamescript:</th>
             <td>
-                {% if server["info"]["gamescript_version"] and server["info"]["gamescript_version"] != GAMESCRIPT_VERSION_NONE %}
-                    {{ server["info"]["gamescript_name"] }} (v{{ server["info"]["gamescript_version"] }})
-                {% else %}
+                {% if server["info"]["gamescript_version"] is none %}
+                    Unknown
+                {% elif server["info"]["gamescript_version"] == GAMESCRIPT_VERSION_NONE %}
                     None
+                {% else %}
+                    {{ server["info"]["gamescript_name"] }} (v{{ server["info"]["gamescript_version"] }})
                 {% endif %}
             </td>
         </tr>
+        {% if server["info"]["newgrfs"] is not none %}
         <tr class="odd">
             <th>NewGRFs in use:</th>
             <td>
                 {{ server["info"]["newgrfs"]|length }}
             </td>
         </tr>
+        {% endif %}
     </tbody>
 </table>
 {% endblock %}


### PR DESCRIPTION
It was now a bit confusing for older servers, as they announced
as if they had no gamescript. But we don't know this, as they don't
tell us.