### PR TITLE
Fix: no longer show the configured maximum spectators

### DIFF
--- a/webclient/templates/server_entry.html
+++ b/webclient/templates/server_entry.html
@@ -70,7 +70,7 @@
         <tr class="even">
             <th>Spectators:</th>
             <td>
-                {{ server["info"]["spectators_on"] }} / {{ server["info"]["spectators_max"] }}
+                {{ server["info"]["spectators_on"] }}
             </td>
         </tr>
         <tr class="odd">


### PR DESCRIPTION
In OpenTTD 12 this is a stub value anyway, and it has never been
useful to show this to users.