### PR TITLE
Add: devcontainer to make development easier

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,4 @@
+FROM mcr.microsoft.com/vscode/devcontainers/python:0-3.8-bullseye as python
+
+# Customized first-run-notice to give clues how to work with this devcontainer.
+COPY .devcontainer/first-run-notice.txt /usr/local/etc/vscode-dev-containers/first-run-notice.txt

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,40 @@
+{
+	"name": "Master Server Web",
+	"runArgs": ["--init"],
+	"build": {
+		"context": "..",
+		"dockerfile": "Dockerfile",
+	},
+
+	"settings": {
+		"python.linting.enabled": true,
+		"python.linting.pylintEnabled": true,
+		"python.formatting.autopep8Path": "/usr/local/py-utils/bin/autopep8",
+		"python.formatting.blackPath": "/usr/local/py-utils/bin/black",
+		"python.formatting.yapfPath": "/usr/local/py-utils/bin/yapf",
+		"python.linting.banditPath": "/usr/local/py-utils/bin/bandit",
+		"python.linting.flake8Path": "/usr/local/py-utils/bin/flake8",
+		"python.linting.mypyPath": "/usr/local/py-utils/bin/mypy",
+		"python.linting.pycodestylePath": "/usr/local/py-utils/bin/pycodestyle",
+		"python.linting.pydocstylePath": "/usr/local/py-utils/bin/pydocstyle",
+		"python.linting.pylintPath": "/usr/local/py-utils/bin/pylint",
+		"files.trimTrailingWhitespace": true
+	},
+
+	"extensions": [
+		"ms-python.python",
+		"ms-python.vscode-pylance"
+	],
+
+	"remoteEnv": {
+        "FLASK_ENV": "development"
+	},
+
+	"forwardPorts": [
+		5000
+	],
+
+	"postStartCommand": ".devcontainer/post-start.sh",
+
+	"remoteUser": "vscode",
+}

--- a/.devcontainer/first-run-notice.txt
+++ b/.devcontainer/first-run-notice.txt
@@ -1,0 +1,5 @@
+👋 Welcome to OpenTTD's Master Server Web devcontainer!
+
+🚂 Press F5 start the webserver (using production API). Under "Ports" you can open the browser to visit the website.
+
+📝 After that, edit away!

--- a/.devcontainer/post-start.sh
+++ b/.devcontainer/post-start.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+set -ex
+
+if [ ! -e ".venv" ]; then
+    python3 -m venv .venv
+fi
+
+# Install latest Python requirements
+.venv/bin/pip install -r requirements.txt

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,5 @@
 __pycache__/
 *.pyc
-/.env
+/.venv/
 /.git/**
 /node_modules

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 __pycache__/
 *.pyc
-/.env
+/.venv/
 /node_modules

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,30 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Server (production API)",
+            "type": "python",
+            "request": "launch",
+            "module": "webclient",
+            "args": [
+                "--api-url",
+                "https://api.master.openttd.org",
+                "run"
+            ]
+        },
+        {
+            "name": "Server (staging API)",
+            "type": "python",
+            "request": "launch",
+            "module": "webclient",
+            "args": [
+                "--api-url",
+                "https://api.master.staging.openttd.org",
+                "run"
+            ]
+        }
+    ]
+}

--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,13 @@
 .PHONY: run venv flake8
 
-run: .env/pyvenv.cfg
-	FLASK_ENV=development .env/bin/python3 -m webclient --api-url "http://localhost:8080" run
+run: .venv/pyvenv.cfg
+	FLASK_ENV=development .venv/bin/python3 -m webclient --api-url "http://localhost:8080" run
 
-venv: .env/pyvenv.cfg
+venv: .venv/pyvenv.cfg
 
-.env/pyvenv.cfg: requirements.txt
-	python3 -m venv .env
-	.env/bin/pip install -r requirements.txt
+.venv/pyvenv.cfg: requirements.txt
+	python3 -m venv .venv
+	.venv/bin/pip install -r requirements.txt
 
 flake8:
 	python3 -m flake8 webclient

--- a/README.md
+++ b/README.md
@@ -18,13 +18,22 @@ It works together with [master-server](https://github.com/OpenTTD/master-server)
 
 This front-end is written in Python 3.7 with Flask.
 
-## Usage
+### Running via devcontainer / VSCode Remote Containers / GitHub Codespaces
+
+If you open up this repository with VSCode Remote Containers or GitHub Codespaces, it will automatically set up the development environment for you.
+
+Press F5 to start the webserver using the production API.
+Go to "Ports" to open the website.
+
+Happy editing!
+
+### Running locally
 
 To start it, you are advised to first create a virtualenv:
 
 ```bash
-python3 -m venv .env
-.env/bin/pip install -r requirements.txt
+python3 -m venv .venv
+.venv/bin/pip install -r requirements.txt
 ```
 
 After this, you can run the flask application by running:


### PR DESCRIPTION
Been experimenting with devcontainers a bit more. This repository is a very easy one. If you are signed up for GitHub Codespaces, it is absolutely worth checking it out. I made it available on https://github.com/TrueBrain/OpenTTD-master-server-web.

But for those that don't want to, I made two records for you.

In less than a minute from looking at the repository to being ready to edit it:
![Uyp7HnpP4w](https://user-images.githubusercontent.com/1663690/139528656-a11b2fde-249a-4403-9997-f05ed07b8b8f.gif)

Starting the webserver is easy as pie:
![P0fgfdhYj3](https://user-images.githubusercontent.com/1663690/139528643-d2aa32d4-cdcb-46f5-b8c8-5ae91cd04237.gif)

