### PR TITLE
Add: show "play time" in server-listing

### DIFF
--- a/webclient/pages/servers.py
+++ b/webclient/pages/servers.py
@@ -95,6 +95,9 @@ def _fix_server_info(server):
     server["info"]["start_date"] = _date_to_string(server["info"]["start_date"])
     server["info"]["game_date"] = _date_to_string(server["info"]["game_date"])
 
+    minutes = int(server["info"]["ticks_playing"] / 37 / 60)
+    server["info"]["time_playing"] = f"{minutes // 60}h {minutes % 60}m"
+
 
 def _split_version(raw_version):
     """

--- a/webclient/static/css/servers.css
+++ b/webclient/static/css/servers.css
@@ -54,7 +54,7 @@
 	width: 15px;
 }
 #server-table .name {
-	width: 562px;
+	width: 492px;
 }
 #server-table .address {
 	width: 100px;
@@ -63,6 +63,9 @@
 	width: 70px;
 }
 #server-table .companies {
+	width: 70px;
+}
+#server-table .play-time {
 	width: 70px;
 }
 #server-table .version {

--- a/webclient/templates/server_entry.html
+++ b/webclient/templates/server_entry.html
@@ -56,36 +56,42 @@
             </td>
         </tr>
         <tr class="even">
+            <th>Play time:</th>
+            <td>
+                {{ server["info"]["time_playing"] }}
+            </td>
+        </tr>
+        <tr class="odd">
             <th>Clients:</th>
             <td>
                 {{ server["info"]["clients_on"] }} / {{ server["info"]["clients_max"] }}
             </td>
         </tr>
-        <tr class="odd">
+        <tr class="even">
             <th>Companies:</th>
             <td>
                 {{ server["info"]["companies_on"] }} / {{ server["info"]["companies_max"] }}
             </td>
         </tr>
-        <tr class="even">
+        <tr class="odd">
             <th>Spectators:</th>
             <td>
                 {{ server["info"]["spectators_on"] }}
             </td>
         </tr>
-        <tr class="odd">
+        <tr class="even">
             <th>Landscape:</th>
             <td>
                 {{ mapsets[server["info"]["map_type"]] }}
             </td>
         </tr>
-        <tr class="even">
+        <tr class="odd">
             <th>Map size:</th>
             <td>
                 {{ server["info"]["map_width"] }} x {{ server["info"]["map_height"] }}
             </td>
         </tr>
-        <tr class="odd">
+        <tr class="even">
             <th>Dedicated server:</th>
             <td>
                 {% if server["info"]["is_dedicated"] == 1 %}
@@ -95,7 +101,7 @@
                 {% endif %}
             </td>
         </tr>
-        <tr class="even">
+        <tr class="odd">
             <th>Gamescript:</th>
             <td>
                 {% if server["info"]["gamescript_version"] is none %}
@@ -108,7 +114,7 @@
             </td>
         </tr>
         {% if server["info"]["newgrfs"] is not none %}
-        <tr class="odd">
+        <tr class="even">
             <th>NewGRFs in use:</th>
             <td>
                 {{ server["info"]["newgrfs"]|length }}

--- a/webclient/templates/server_list.html
+++ b/webclient/templates/server_list.html
@@ -20,6 +20,7 @@
         <th class="name">Name</th>
         <th class="clients">Clients</th>
         <th class="companies">Companies</th>
+        <th class="play-time">Play time</th>
         <th class="version">Version</th>
         <th class="icon-password"></th>
         <th class="icon-grf"></th>
@@ -50,6 +51,9 @@
         </td>
         <td>
             {{ server['info']['companies_on'] }} / {{ server['info']['companies_max'] }}
+        </td>
+        <td>
+            {{ server['info']['time_playing'] }}
         </td>
         <td>
             <div class="nowrap" style="width: 120px;">


### PR DESCRIPTION
In 14.0 we introduce "Play Time" in-game, where you can see, roughly, how many hours a server has been running unpaused for.

Bring this information to the website too.

![image](https://github.com/OpenTTD/master-server-web/assets/1663690/13e0f3b7-8a56-46a9-96bc-cd4f6c00341f)
